### PR TITLE
bugfixes: fix next turn and missile queue bugs

### DIFF
--- a/Assets/Code/Scripts/Battleship.cs
+++ b/Assets/Code/Scripts/Battleship.cs
@@ -65,6 +65,7 @@ namespace Code.Scripts
 
         public override bool PrepareToFire(int initialLayer, out FireReservation reservation)
         {
+            Debug.Log("Battleship preparing to fire");
             SeaWar.IGameboardFollowTarget followTarget = null;
             var firePackages = new List<GunTurret.FirePackage>();
             foreach (var gunTurret in gunTurrets)

--- a/Assets/Code/Scripts/F35.cs
+++ b/Assets/Code/Scripts/F35.cs
@@ -327,6 +327,8 @@ namespace Code.Scripts
             // Get the missile that will be fired (or null if no missile is available)
             if (!_missiles.TryFirstOrDefault(ele => ele.Value.Available, out var available)) return false;
 
+            Debug.Log("F35 preparing to fire");
+
             available.Value.Available = false;
             targetReservation = new TargetReservation(missilePool.TakeFromPool());
             targetReservation.Missile.SetLayer(initialLayer);
@@ -591,8 +593,16 @@ namespace Code.Scripts
             var haveMadeVisible = false;
             missile.LaunchMissile(_currentSpeed, target, _ =>
             {
-                missilePool.ReturnToPool(missile);
-                onImpact?.Invoke();
+                if (missile != null)
+                {
+                    Debug.Log($"F35 returning missile to pool");
+                    missilePool.ReturnToPool(missile);
+                    onImpact?.Invoke();
+                }
+                else
+                {
+                    Debug.Log($"F35 skipping null missile");
+                }
             },
             () => { },
                 (_, _, flightFraction) =>

--- a/Assets/Code/Scripts/LCS.cs
+++ b/Assets/Code/Scripts/LCS.cs
@@ -67,6 +67,7 @@ namespace Code.Scripts
 
         public override bool PrepareToFire(int initialLayer, out FireReservation reservation)
         {
+            UnityEngine.Debug.Log("LCS preparing to fire");
             var firePackage = deckGun.PrepareFirePackage(initialLayer, burstCount, out var followTarget);
             reservation = new LcsFireReservation(GetIdent(), FireAtTarget, followTarget, firePackage);
             return true;

--- a/Assets/Code/Scripts/MissilePool.cs
+++ b/Assets/Code/Scripts/MissilePool.cs
@@ -24,12 +24,31 @@ namespace Code.Scripts
         {
             for (var i = 0; i < poolSize; i++) _available.Enqueue(MakeMissile());
         }
-        
-        public void ReturnToPool(MissileBase missile) => _available.Enqueue(missile);
+
+        public void ReturnToPool(MissileBase missile)
+        {
+            Debug.Log("missile pool count before enqueue: " + _available.Count.ToString());
+            _available.Enqueue(missile);
+            Debug.Log($"Returned missile to pool: {missile.name}");
+            Debug.Log("missile pool count after enqueue: " + _available.Count.ToString());
+        }
         
         public MissileBase TakeFromPool()
         {
-            if (!_available.TryDequeue(out var missile)) missile = MakeMissile();
+            Debug.Log("missile pool count before dequeue attempt: " + _available.Count.ToString());
+
+            if (!_available.TryDequeue(out var missile))
+            {
+                Debug.LogWarning("No available missiles in the pool, creating a new one.");
+                missile = MakeMissile();
+            }
+            else
+            {
+                Debug.Log($"Took missile from pool: {missile.name}");
+            }
+
+            Debug.Log("missile pool count after dequeue attempt: " + _available.Count.ToString());
+
             return missile;
         }
     }

--- a/Assets/Code/Scripts/SeaWar.cs
+++ b/Assets/Code/Scripts/SeaWar.cs
@@ -1568,7 +1568,20 @@ namespace Code.Scripts
         {
             // Obtain the next commander who's still playing
             Commander commander;
-            while (!Commanders[commander = IncrementAttackingCommander()].Playing.Value) {}
+            int attempts = 0; // Add a counter to prevent infinite loop
+            while (!Commanders[commander = IncrementAttackingCommander()].Playing.Value && attempts < Commanders.Count)
+            {
+                attempts++;
+            }
+
+            if (attempts == Commanders.Count)
+            {
+                Debug.LogWarning("No commanders are currently playing.");
+                // todo (sclokey): Figure out what to do to in this case where all players are
+                // somehow null. Also figure out why any of the players are showing up null when
+                // the glasses are still plugged in.
+                return;
+            }
             
             _launchWarningShown = false;
             _commanderUnderAttack = null;

--- a/Assets/Code/Scripts/SeaWar.cs
+++ b/Assets/Code/Scripts/SeaWar.cs
@@ -1568,7 +1568,17 @@ namespace Code.Scripts
         {
             // Obtain the next commander who's still playing
             Commander commander;
-            while (!Commanders[commander = IncrementAttackingCommander()].Playing.Value) {}
+            int attempts = 0; // Add a counter to prevent infinite loop
+            while (!Commanders[commander = IncrementAttackingCommander()].Playing.Value && attempts < Commanders.Count)
+            {
+                attempts++;
+            }
+
+            if (attempts == Commanders.Count)
+            {
+                Debug.LogWarning("No commanders are currently playing. Resetting game state.");
+                return;
+            }
             
             _launchWarningShown = false;
             _commanderUnderAttack = null;


### PR DESCRIPTION
There was a bug in SeaWar.cs where one player would end his/her turn but the next player's turn wouldn't start. Fixed this.

After fixing the above bug, I ran into another bug where sometimess the destroyer or submarine would attempt to fire a missile that had returned null after being taken from the pool. It looks like this was being caused by the submarine putting 2 missiles back into the missile pool on MaybeFireQueuedMissiles. The second of those two missiles was null and so would cause issues when pulled out. I need to clean this change up and also figure out why the destroyer and submarine try to return 2 missiles to the pool after only taking out one, but I'm able to play through an entire game with this change. Note: the destroyer also returns 2 missiles to the pool, but neither are null. This results in the number of missiles in the pool increasing throughout the game, but that doesn't seem to cause an issue. Need to look into this.

Below are a couple pictures showing that the game can now be played to completion:
![Capture](https://github.com/user-attachments/assets/10f88636-15f9-43d0-b0e7-f08b05bf0dcb)
![Capture1](https://github.com/user-attachments/assets/4b846b69-a36f-414f-85de-dea02187c9d5)
![Capture3](https://github.com/user-attachments/assets/7713865d-91df-4deb-89da-50a61c815a84)
